### PR TITLE
Working clustering filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea/
+cmake-build-debug/
+*.o
+.idea/*
+3DCopy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.6)
+project(filter)
+
+set(CMAKE_CXX_STANDARD 11)
+
+find_package(PCL 1.3 REQUIRED)
+include_directories(${PCL_INCLUDE_DIRS})
+link_directories(${PCL_LIBRARY_DIRS})
+add_definitions(${PCL_DEFINITIONS})
+
+set(SOURCE_FILES src/main.cpp src/Filter.cpp src/include/Filter.h)
+add_executable(filter ${SOURCE_FILES})
+
+target_link_libraries(filter ${PCL_COMMON_LIBRARIES} ${PCL_IO_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,4 +11,4 @@ add_definitions(${PCL_DEFINITIONS})
 set(SOURCE_FILES src/main.cpp src/Filter.cpp src/include/Filter.h)
 add_executable(filter ${SOURCE_FILES})
 
-target_link_libraries(filter ${PCL_COMMON_LIBRARIES} ${PCL_IO_LIBRARIES})
+target_link_libraries(filter ${PCL_LIBRARIES})

--- a/src/Filter.cpp
+++ b/src/Filter.cpp
@@ -1,9 +1,151 @@
-//
-// Created by martin on 2017-04-04.
-//
-
 #include "include/Filter.h"
+#include <pcl/common/transforms.h>
+#include <pcl/common/centroid.h>
+#include <pcl/filters/passthrough.h>
+#include <pcl/filters/radius_outlier_removal.h>
+#include <pcl/filters/extract_indices.h>
+#include <pcl/features/normal_3d.h>
+#include <pcl/kdtree/kdtree.h>
+#include <pcl/segmentation/extract_clusters.h>
 
-void Filter::filter() {
+void Filter::filter(PointCloud::ConstPtr cloud_in, PointCloud::Ptr cloud_out, int rotation) const {
+    // Use a pass through filter to remove all points outside of specific coordinates
+    pcl::PassThrough<pcl::PointXYZ> pt_filter;
+    pt_filter.setInputCloud(cloud_in);
+
+    // Do initial rough filtering on the x axis to remove noise data
+    pt_filter.setFilterFieldName("x");
+    pt_filter.setFilterLimits(x_min, x_max);
+    pt_filter.setFilterLimitsNegative(false);
+    pt_filter.filter(*cloud_out);
+
+    // Filter on the z axis to remove the plane of noise data in the
+    // beginning of the scan
+    pt_filter.setInputCloud(cloud_out);
+    pt_filter.setFilterFieldName("z");
+    pt_filter.setFilterLimits(z_min, z_max);
+    pt_filter.setFilterLimitsNegative(true);
+    pt_filter.filter(*cloud_out);
+
+    // Filter on the y axis
+    pt_filter.setInputCloud(cloud_out);
+    pt_filter.setFilterFieldName("y");
+    pt_filter.setFilterLimits(y_min, y_min);
+    pt_filter.setFilterLimitsNegative(false);
+    pt_filter.filter(*cloud_out);
+
+    // Remove points that are far away from other points
+    pcl::RadiusOutlierRemoval<pcl::PointXYZ> outlier_filter;
+    outlier_filter.setInputCloud(cloud_out);
+    outlier_filter.setRadiusSearch(0.8);
+    outlier_filter.setMinNeighborsInRadius(2);
+    outlier_filter.filter(*cloud_out);
+
+    // Extract the stick holding the object and compute it's centroid (center of mass) for later
+    PointCloud::Ptr stick(new PointCloud);
+    remove_stick(cloud_out, stick, true);
+    Eigen::Vector4f stick_centroid(Eigen::Vector4f::Zero());
+    pcl::compute3DCentroid(*stick, stick_centroid);
+
+    std::cout << "Centroid:" << std::endl << stick_centroid.head<3>() << std::endl;
+
+    // Remove the stick the object is attached to
+    remove_stick(cloud_out, cloud_out);
+
+    // Translate the object to move the center of the object to the origin (approximately).
+    Eigen::Affine3f translation_transform(Eigen::Affine3f::Identity());
+    translation_transform.translation() << -528.0, -346.0, 591.0;
+    pcl::transformPointCloud(*cloud_out, *cloud_out, translation_transform);
+
+    // Adjust the position of the object so the stick is in the center.
+    // This means the object is in the origin.
+    translation_transform.translation() << 0.0, -stick_centroid(1, 0), -stick_centroid(2, 0);
+    pcl::transformPointCloud(*cloud_out, *cloud_out, translation_transform);
+
+    // Scale the point cloud by half to make it the correct proportions.
+    // The scaling factor 0.5 assumes the scans are run with cart speed 200 mm/s.
+    Eigen::Affine3f scale_transform(Eigen::Affine3f::Identity());
+    scale_transform.scale(Eigen::Vector3f(1, 1, scaling_factor));
+    pcl::transformPointCloud(*cloud_out, *cloud_out, scale_transform);
+
+    // Rotate the object around the x axis to match the objects real world rotation
+    Eigen::Matrix3f rotation_matrix(Eigen::AngleAxisf((rotation*M_PI) / 180, Eigen::Vector3f::UnitX()));
+    Eigen::Affine3f rotation_transform(Eigen::Affine3f::Identity());
+    rotation_transform.rotate(rotation_matrix);
+    pcl::transformPointCloud(*cloud_out, *cloud_out, rotation_transform);
+
     return;
+}
+
+bool Filter::remove_stick(PointCloud::ConstPtr cloud_in, PointCloud::Ptr cloud_out, bool inverse) const
+{
+    // Create the KdTree object for the search method of the extraction
+    pcl::search::KdTree<pcl::PointXYZ>::Ptr search_tree(new pcl::search::KdTree<pcl::PointXYZ>);
+    search_tree->setInputCloud(cloud_in);
+
+    // Create the object for extracting cluster in cloud_in
+    std::vector<pcl::PointIndices> cluster_indices;
+    pcl::EuclideanClusterExtraction<pcl::PointXYZ> cluster_extraction;
+    cluster_extraction.setInputCloud(cloud_in);
+
+    // Set the maximum distance between two points in a cluster to 4 mm
+    cluster_extraction.setClusterTolerance(4.0);
+
+    // Set a cluster to be between 10 and 25000 points
+    cluster_extraction.setMinClusterSize(10);
+    cluster_extraction.setMaxClusterSize(25000);
+
+    // Perform the euclidean cluster extraction algorithm
+    cluster_extraction.setSearchMethod(search_tree);
+    cluster_extraction.extract(cluster_indices);
+
+    // Generate all the individual cluster point clouds
+    std::vector<PointCloud::Ptr> clusters;
+    for (std::vector<pcl::PointIndices>::const_iterator it = cluster_indices.begin(); it != cluster_indices.end(); ++it) {
+        PointCloud::Ptr cluster(new PointCloud);
+
+        // For every list of indices, add all the points to a point cloud
+        for (std::vector<int>::const_iterator pit = it->indices.begin(); pit != it->indices.end(); ++pit) {
+            cluster->points.push_back(cloud_in->points[*pit]);
+        }
+
+        cluster->width = cluster->points.size();
+        cluster->height = 1;
+        cluster->is_dense = true;
+
+        clusters.push_back(cluster);
+    }
+
+
+    if (!clusters.empty()) {
+        std::vector<PointCloud::Ptr> good_clusters;
+
+        for (size_t i = 0; i < clusters.size(); ++i) {
+            Eigen::Vector4f centroid(Eigen::Vector4f::Zero());
+            pcl::compute3DCentroid(*clusters.at(i), centroid);
+
+            std::cout << "Centroid: " << std::endl << centroid << std::endl << std::endl;
+
+            if (!inverse && centroid(0, 0) < 510) {
+                good_clusters.push_back(clusters.at(i));
+            } else if (inverse && centroid(0, 0) > 510) {
+                good_clusters.push_back(clusters.at(i));
+            }
+        }
+
+        std::cout << "Good clusters: " << good_clusters.size() << std::endl;
+        for (size_t i = 0; i < good_clusters.size(); ++i) {
+            std::cout << "Adding cluster " << i << std::endl;
+            if (i == 0) {
+                *cloud_out = *good_clusters.at(i);
+            } else {
+                *cloud_out += *good_clusters.at(i);
+            }
+        }
+
+        return true;
+    } else {
+        *cloud_out = *cloud_in;
+        return false;
+    }
 }

--- a/src/Filter.cpp
+++ b/src/Filter.cpp
@@ -1,0 +1,9 @@
+//
+// Created by martin on 2017-04-04.
+//
+
+#include "include/Filter.h"
+
+void Filter::filter() {
+    return;
+}

--- a/src/include/Filter.h
+++ b/src/include/Filter.h
@@ -1,14 +1,28 @@
-//
-// Created by martin on 2017-04-04.
-//
-
 #ifndef FILTER_FILTER_H
 #define FILTER_FILTER_H
 
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
 
 class Filter {
+    private:
+        float scaling_factor = 0.5f;
+
+        int x_min = 310, x_max = 568;
+        int y_min = 250, y_max = 580;
+        int z_min = -1, z_max = 1;
+
+        void move_to_origin();
+        bool remove_stick(PointCloud::ConstPtr cloud_in, PointCloud::Ptr cloud_out, bool inverse = false) const;
+
     public:
-        void filter();
+        void filter(PointCloud::ConstPtr cloud_in, PointCloud::Ptr cloud_out, int rotation = 0) const;
+
+
+        float get_scaling_factor() const { return scaling_factor; }
+        void set_scaling_factor(float scaling_factor) { Filter::scaling_factor = scaling_factor; }
 };
 
 

--- a/src/include/Filter.h
+++ b/src/include/Filter.h
@@ -1,0 +1,15 @@
+//
+// Created by martin on 2017-04-04.
+//
+
+#ifndef FILTER_FILTER_H
+#define FILTER_FILTER_H
+
+
+class Filter {
+    public:
+        void filter();
+};
+
+
+#endif //FILTER_FILTER_H

--- a/src/include/Filter.h
+++ b/src/include/Filter.h
@@ -8,19 +8,27 @@ typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
 
 class Filter {
     private:
+        // The scaling factor 0.5 assumes the scans are run with cart speed 200 mm/s.
         float scaling_factor = 0.5f;
+        int cluster_x_max = 10;
 
+        // Move the object to the origin by finding the stick and centering it
+        void move_to_origin(PointCloud::ConstPtr cloud_in, PointCloud::Ptr cloud_out) const;
+
+        // Remove the stick holding the object from the point cloud.
+        // Can also remove everything but the stick by passing inverse = true
+        bool remove_stick(PointCloud::ConstPtr cloud_in, PointCloud::Ptr cloud_out, bool inverse = false) const;
+
+    public:
+        // Limits for the initial rough pass through filter
         int x_min = 310, x_max = 568;
         int y_min = 250, y_max = 580;
         int z_min = -1, z_max = 1;
 
-        void move_to_origin();
-        bool remove_stick(PointCloud::ConstPtr cloud_in, PointCloud::Ptr cloud_out, bool inverse = false) const;
+        // Perform the filtering
+        void filter(PointCloud::ConstPtr cloud_in, PointCloud::Ptr cloud_out, int rotation, int curve) const;
 
-    public:
-        void filter(PointCloud::ConstPtr cloud_in, PointCloud::Ptr cloud_out, int rotation = 0) const;
-
-
+        // Functions for setting the scaling factor (for different cart speeds)
         float get_scaling_factor() const { return scaling_factor; }
         void set_scaling_factor(float scaling_factor) { Filter::scaling_factor = scaling_factor; }
 };

--- a/src/include/Filter.h
+++ b/src/include/Filter.h
@@ -12,11 +12,7 @@ class Filter {
         float scaling_factor = 0.5f;
         int cluster_x_max = 10;
 
-        // Move the object to the origin by finding the stick and centering it
         void move_to_origin(PointCloud::ConstPtr cloud_in, PointCloud::Ptr cloud_out) const;
-
-        // Remove the stick holding the object from the point cloud.
-        // Can also remove everything but the stick by passing inverse = true
         bool remove_stick(PointCloud::ConstPtr cloud_in, PointCloud::Ptr cloud_out, bool inverse = false) const;
 
     public:
@@ -25,8 +21,7 @@ class Filter {
         int y_min = 250, y_max = 580;
         int z_min = -1, z_max = 1;
 
-        // Perform the filtering
-        void filter(PointCloud::ConstPtr cloud_in, PointCloud::Ptr cloud_out, int rotation, int curve) const;
+        void filter(PointCloud::ConstPtr cloud_in, PointCloud::Ptr cloud_out) const;
 
         // Functions for setting the scaling factor (for different cart speeds)
         float get_scaling_factor() const { return scaling_factor; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,10 +29,10 @@ int main(int argc, char** argv) {
                     return -1;
                 }
 
-                filter.filter(cloud_in, cloud_out, 0, 0);
+                filter.filter(cloud_in, cloud_out);
 
                 std::string filename = p.stem().string() + "_filtered.pcd";
-                std::cout << "Saving to " << filename << std::endl;
+                std::cout << "Saving filtered cloud to " << filename << std::endl;
                 pcl::io::savePCDFile(filename, *cloud_out);
 
             } else if (fs::is_directory(p)) {
@@ -45,14 +45,13 @@ int main(int argc, char** argv) {
                             return -1;
                         }
 
-                        filter.filter(cloud_in, cloud_out, 0, 0);
+                        filter.filter(cloud_in, cloud_out);
 
                         std::string filename = p.string() + "_filtered/" + it->path().filename().string();
                         fs::create_directory(fs::path(filename).parent_path());
 
-                        std::cout << "Saving to " << filename << std::endl;
+                        std::cout << "Saving filtered cloud to " << filename << std::endl;
                         pcl::io::savePCDFile(filename, *cloud_out);
-
                     }
                 }
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+#include <pcl/io/pcd_io.h>
+
+#include "include/Filter.h"
+
+int main(int argc, char** argv) {
+    Filter filter;
+
+    
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,6 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/visualization/pcl_visualizer.h>
 #include <pcl/common/centroid.h>
-#include <pcl/common/transforms.h>
 
 #include "include/Filter.h"
 
@@ -25,33 +24,38 @@ int main(int argc, char** argv) {
             if (fs::is_regular_file(p)) {
                 PointCloud::Ptr cloud_in(new PointCloud), cloud_out(new PointCloud);
 
-                if (pcl::io::loadPCDFile(p.native(), *cloud_in) == -1) {
+                if (pcl::io::loadPCDFile(p.string(), *cloud_in) == -1) {
                     PCL_ERROR("Couldn't read cloud file\n");
                     return -1;
                 }
 
-                filter.filter(cloud_in, cloud_out);
+                filter.filter(cloud_in, cloud_out, 0, 0);
 
                 std::string filename = p.stem().string() + "_filtered.pcd";
+                std::cout << "Saving to " << filename << std::endl;
                 pcl::io::savePCDFile(filename, *cloud_out);
 
             } else if (fs::is_directory(p)) {
+                for (auto it = fs::directory_iterator(p); it != fs::directory_iterator(); ++it) {
+                    if (fs::is_regular_file(it->path())) {
+                        PointCloud::Ptr cloud_in(new PointCloud), cloud_out(new PointCloud);
 
+                        if (pcl::io::loadPCDFile(it->path().string(), *cloud_in) == -1) {
+                            PCL_ERROR("Couldn't read cloud file\n");
+                            return -1;
+                        }
+
+                        filter.filter(cloud_in, cloud_out, 0, 0);
+
+                        std::string filename = p.string() + "_filtered/" + it->path().filename().string();
+                        fs::create_directory(fs::path(filename).parent_path());
+
+                        std::cout << "Saving to " << filename << std::endl;
+                        pcl::io::savePCDFile(filename, *cloud_out);
+
+                    }
+                }
             }
         }
     }
-
-
-    /*
-    pcl::visualization::PCLVisualizer viewer;
-    viewer.addCoordinateSystem(10);
-
-    pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> cloud_in_color(cloud_in, 200, 25, 25);
-    viewer.addPointCloud(cloud_in, cloud_in_color, "cl_in");
-
-    pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> cloud_in2_color(cloud_in2, 25, 200, 25);
-    viewer.addPointCloud(cloud_in2, cloud_in2_color, "cl_in2");
-
-    viewer.spin();
-    */
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,57 @@
 #include <iostream>
+#include <boost/filesystem.hpp>
 #include <pcl/io/pcd_io.h>
+#include <pcl/visualization/pcl_visualizer.h>
+#include <pcl/common/centroid.h>
+#include <pcl/common/transforms.h>
 
 #include "include/Filter.h"
 
+namespace fs = boost::filesystem;
+
 int main(int argc, char** argv) {
+    if (argc == 1) {
+        std::cout << "Usage: filter sources" << std::endl;
+        std::cout << "Where sources is a list of files or directories." << std::endl;
+        return 0;
+    }
+
     Filter filter;
 
-    
+    for (int i = 1; i < argc; ++i) {
+        fs::path p(argv[i]);
+
+        if (fs::exists(p)) {
+            if (fs::is_regular_file(p)) {
+                PointCloud::Ptr cloud_in(new PointCloud), cloud_out(new PointCloud);
+
+                if (pcl::io::loadPCDFile(p.native(), *cloud_in) == -1) {
+                    PCL_ERROR("Couldn't read cloud file\n");
+                    return -1;
+                }
+
+                filter.filter(cloud_in, cloud_out);
+
+                std::string filename = p.stem().string() + "_filtered.pcd";
+                pcl::io::savePCDFile(filename, *cloud_out);
+
+            } else if (fs::is_directory(p)) {
+
+            }
+        }
+    }
+
+
+    /*
+    pcl::visualization::PCLVisualizer viewer;
+    viewer.addCoordinateSystem(10);
+
+    pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> cloud_in_color(cloud_in, 200, 25, 25);
+    viewer.addPointCloud(cloud_in, cloud_in_color, "cl_in");
+
+    pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> cloud_in2_color(cloud_in2, 25, 200, 25);
+    viewer.addPointCloud(cloud_in2, cloud_in2_color, "cl_in2");
+
+    viewer.spin();
+    */
 }


### PR DESCRIPTION
Har nu fungerande kod för att generellt filtrera objekt. Koden fungerar genom att dela upp en skanning i kluster och sedan räkna ut en slags "tyngdpunkt" för alla kluster. De kluster som ligger under en viss gräns räknas som pinnen och filtreras bort. Filtret lägger även punktmolnet i origo.

För att testa finns ett väldigt simpelt CLI som tar in godtyckligt antal filer och mappar som argument och filtrerar alla och sparar dem till fil. Filtret kan även användas i annan kod genom att importera klassen Filter och använda den.

Jag har testat att låta den filtrera hela mappen med skanningar från kyrkan som heter newchurch på usb-minnet.