### PR TITLE
Proper CLI with parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ cmake-build-debug/
 *.o
 .idea/*
 3DCopy
+*.pcd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,12 @@ project(filter)
 set(CMAKE_CXX_STANDARD 11)
 
 find_package(PCL 1.3 REQUIRED)
-include_directories(${PCL_INCLUDE_DIRS})
+find_package(Boost 1.40 COMPONENTS program_options REQUIRED)
+include_directories(${PCL_INCLUDE_DIRS} ${Boost_INCLUDE_DIR})
 link_directories(${PCL_LIBRARY_DIRS})
 add_definitions(${PCL_DEFINITIONS})
 
 set(SOURCE_FILES src/main.cpp src/Filter.cpp src/include/Filter.h)
 add_executable(filter ${SOURCE_FILES})
 
-target_link_libraries(filter ${PCL_LIBRARIES})
+target_link_libraries(filter ${PCL_LIBRARIES} ${Boost_LIBRARIES})

--- a/src/Filter.cpp
+++ b/src/Filter.cpp
@@ -148,9 +148,9 @@ bool Filter::remove_stick(PointCloud::ConstPtr cloud_in, PointCloud::Ptr cloud_o
             Eigen::Vector4f centroid(Eigen::Vector4f::Zero());
             pcl::compute3DCentroid(*clusters.at(i), centroid);
 
-            if (!inverse && centroid(0, 0) < cluster_x_max) {
+            if (!inverse && centroid(0, 0) < cluster_cutoff) {
                 good_clusters.push_back(clusters[i]);
-            } else if (inverse && centroid(0, 0) >= cluster_x_max) {
+            } else if (inverse && centroid(0, 0) >= cluster_cutoff) {
                 good_clusters.push_back(clusters[i]);
             }
         }

--- a/src/include/Filter.h
+++ b/src/include/Filter.h
@@ -10,7 +10,7 @@ class Filter {
     private:
         // The scaling factor 0.5 assumes the scans are run with cart speed 200 mm/s.
         float scaling_factor = 0.5f;
-        int cluster_x_max = 10;
+        int cluster_cutoff = 10;
 
         void move_to_origin(PointCloud::ConstPtr cloud_in, PointCloud::Ptr cloud_out) const;
         bool remove_stick(PointCloud::ConstPtr cloud_in, PointCloud::Ptr cloud_out, bool inverse = false) const;
@@ -26,6 +26,11 @@ class Filter {
         // Functions for setting the scaling factor (for different cart speeds)
         float get_scaling_factor() const { return scaling_factor; }
         void set_scaling_factor(float scaling_factor) { Filter::scaling_factor = scaling_factor; }
+
+        // Functions for setting the clusters height limit in mm
+        // A lower value means the object is placed higher up
+        int get_cluster_cutoff() const { return cluster_cutoff; }
+        void set_cluster_cutoff(int cluster_x_max) { Filter::cluster_cutoff = cluster_x_max; }
 };
 
 


### PR DESCRIPTION
Man kan nu skicka in höjden som filtret använder som gräns för att välja vad som är objekt och vad som är pinne till programmet som argument. Man kan även sätta scaling-faktorn ifall det skulle behövas någon gång.

Nu använder programmet ett ordentligt CLI med lite felhantering och så. Det är även enkelt att lägga till fler inparametrar i framtiden ifall vi kommer på något mer som behövs.